### PR TITLE
Add a specific error message for when the game is not running

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,25 @@
 #![feature(naked_functions)]
 #![feature(llvm_asm)]
-mod zero;
+
+#[cfg(feature = "kiwami2")]
 mod kiwami2;
 
+#[cfg(not(feature = "kiwami2"))]
+mod zero;
+
 fn main() {
-    if cfg!(feature = "kiwami2") {
-        kiwami2::main();
-    } else {
-        zero::main();
-    }
+    #[cfg(feature = "kiwami2")]
+    let result = kiwami2::main();
+
+    #[cfg(not(feature = "kiwami2"))]
+    let result = zero::main();
+
+    // Slightly nicer way to print exit codes
+    std::process::exit(match result {
+        Ok(_) => 0,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            1
+        }
+    })
 }

--- a/src/zero.rs
+++ b/src/zero.rs
@@ -2,6 +2,7 @@ use memory_rs::process::process_wrapper::Process;
 use winapi::um::winuser;
 use winapi::um::winuser::{GetCursorPos, SetCursorPos, GetAsyncKeyState};
 use winapi::shared::windef::{POINT};
+use std::io::{Error, ErrorKind};
 use std::thread;
 use std::time::{Duration, Instant};
 use std::f32;
@@ -55,14 +56,27 @@ fn calc_new_focus_point(cam_x: f32, cam_z: f32,
 }
 
 
-pub fn main() {
+pub fn main() -> Result<(), Error> {
     let mut mouse_pos: POINT = POINT::default();
 
     // latest mouse positions
     let mut latest_x = 0;
     let mut latest_y = 0;
 
-    let yakuza = Process::new("Yakuza0.exe");
+    let yakuza = Process::new("Yakuza0.exe").map_err(|err| {
+        if let Some(os_error) = err.raw_os_error() {
+            // OS Error 18 is ERROR_NO_MORE_FILES, which in this case indicates
+            // a matching process is not currently running on the system.
+            //
+            // We provide a slightly nicer error here, because this is the most
+            // common error we get, and let others fall through to be displayed
+            if os_error == 18 {
+                return Error::new(ErrorKind::NotFound, "Yakuza 0 needs to be running");
+            }
+        }
+
+        err
+    })?;
 
     let entry_point: usize = 0x18FD38;
 


### PR DESCRIPTION
This takes advantage of the updates in etra0/memory-rs#4 which return `Result` types to provide a more user-friendly message if finding the running game fails.

Firstly, it updates `main.rs` to only compile in the module for the specific game, and then to print the error and exit with an error code.

Secondly, both the zero and kiwami2 modules have been updated to return a Result, and to map the [Windows OS error 18 (`ERROR_NO_MORE_FILES`)](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-) to a helpful error message about the game not currently running.

Now, instead of a panic, you get `Error: Yakuza 0 needs to be running`!

fixes #1