### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,28 +494,3 @@ dependencies = [
  "winapi",
  "winres",
 ]
-
-[[package]]
-name = "yakuza6"
-version = "0.1.0"
-dependencies = [
- "cc",
- "log",
- "memory-rs",
- "nalgebra-glm",
- "simplelog",
- "termcolor",
- "winapi",
- "winres",
-]
-
-[[package]]
-name = "yakuza6-freecam"
-version = "0.1.0"
-dependencies = [
- "cc",
- "memory-rs",
- "simple_injector",
- "winres",
- "yakuza6",
-]

--- a/kiwami/src/main.rs
+++ b/kiwami/src/main.rs
@@ -179,9 +179,9 @@ pub fn main() -> Result<(), Error> {
 
         // to scroll infinitely
         restart_mouse = !restart_mouse;
-        unsafe {
-            if (controller_state & 0x11 == 0x11)
-                || (GetAsyncKeyState(winuser::VK_PAUSE) as u32 & 0x8000) != 0
+        
+            if unsafe {(controller_state & 0x11 == 0x11)
+                || (GetAsyncKeyState(winuser::VK_PAUSE) as u32 & 0x8000) != 0 }
             {
                 active = !active;
                 if controller_state & 0x11 != 0x11 {
@@ -198,7 +198,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if active & (GetAsyncKeyState(winuser::VK_DELETE) as u32 & 0x8000 != 0) {
+            if unsafe { active & (GetAsyncKeyState(winuser::VK_DELETE) as u32 & 0x8000 != 0) } {
                 capture_mouse = !capture_mouse;
                 let c_status = if !capture_mouse {
                     "Deattached"
@@ -209,8 +209,8 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if (controller_state & 0x14 == 0x14)
-                || (GetAsyncKeyState(winuser::VK_END) as u32 & 0x8000) != 0
+            if unsafe { (controller_state & 0x14 == 0x14)
+                || (GetAsyncKeyState(winuser::VK_END) as u32 & 0x8000) != 0 }
             {
                 pause_world = !pause_world;
                 println!("status of pausing: {}", pause_world);
@@ -221,6 +221,6 @@ pub fn main() -> Result<(), Error> {
                 }
                 thread::sleep(Duration::from_millis(500));
             }
-        }
+        
     }
 }

--- a/kiwami2/src/main.rs
+++ b/kiwami2/src/main.rs
@@ -40,10 +40,10 @@ fn trigger_pause(process: &Process, addr: usize) {
 fn remove_ui(process: &Process, activate: bool) {
     let offsets: Vec<usize> = vec![0x291D1DC, 0x291D1D0, 0x291D1EC, 0x291D1E8, 0x291D1E4];
 
-    unsafe {
-        if ORIGINAL_VAL_UI[0] == 0 {
+    
+        if unsafe {ORIGINAL_VAL_UI[0] == 0} {
             for (i, offset) in offsets.iter().enumerate() {
-                ORIGINAL_VAL_UI[i] = process.read_value::<u32>(*offset, false);
+                unsafe { ORIGINAL_VAL_UI[i] = process.read_value::<u32>(*offset, false) };
             }
         }
 
@@ -51,10 +51,10 @@ fn remove_ui(process: &Process, activate: bool) {
             if activate {
                 process.write_value::<i32>(*offset, -1, false);
             } else {
-                process.write_value::<u32>(*offset, ORIGINAL_VAL_UI[i], false);
+                unsafe { process.write_value::<u32>(*offset, ORIGINAL_VAL_UI[i], false) };
             }
         }
-    }
+    
 }
 
 pub fn main() -> Result<(), Error> {
@@ -259,9 +259,9 @@ pub fn main() -> Result<(), Error> {
 
         // to scroll infinitely
         restart_mouse = !restart_mouse;
-        unsafe {
-            if detect_activation_by_controller(controller_state)
-                || ((GetAsyncKeyState(winuser::VK_PAUSE) as u32 & 0x8000) != 0)
+        
+            if unsafe {detect_activation_by_controller(controller_state)
+                || ((GetAsyncKeyState(winuser::VK_PAUSE) as u32 & 0x8000) != 0)}
             {
                 active = !active;
                 if !detect_activation_by_controller(controller_state) {
@@ -283,7 +283,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if (GetAsyncKeyState(winuser::VK_HOME) as u32 & 0x8000) != 0 {
+            if unsafe {(GetAsyncKeyState(winuser::VK_HOME) as u32 & 0x8000) != 0} {
                 active = !active;
                 capture_mouse = active;
 
@@ -301,7 +301,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if (GetAsyncKeyState(winuser::VK_END) as u32 & 0x8000) != 0 {
+            if unsafe {(GetAsyncKeyState(winuser::VK_END) as u32 & 0x8000) != 0} {
                 active = !active;
                 capture_mouse = active;
 
@@ -318,7 +318,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if active & (GetAsyncKeyState(winuser::VK_DELETE) as u32 & 0x8000 != 0) {
+            if unsafe {active & (GetAsyncKeyState(winuser::VK_DELETE) as u32 & 0x8000 != 0)} {
                 capture_mouse = !capture_mouse;
                 let c_status = if !capture_mouse {
                     "Deattached"
@@ -328,6 +328,6 @@ pub fn main() -> Result<(), Error> {
                 println!("status of mouse: {}", c_status);
                 thread::sleep(Duration::from_millis(500));
             }
-        }
+        
     }
 }

--- a/kiwami2/src/main.rs
+++ b/kiwami2/src/main.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use winapi::shared::windef::POINT;
 use winapi::um::winuser;
 use winapi::um::winuser::{GetAsyncKeyState, GetCursorPos, SetCursorPos};
-
+use ctypes::c_int;
 const INITIAL_POS: i32 = 500;
 static mut ORIGINAL_VAL_UI: [u32; 5] = [0; 5];
 
@@ -260,8 +260,8 @@ pub fn main() -> Result<(), Error> {
         // to scroll infinitely
         restart_mouse = !restart_mouse;
         
-            if unsafe {detect_activation_by_controller(controller_state)
-                || ((GetAsyncKeyState(winuser::VK_PAUSE) as u32 & 0x8000) != 0)}
+            if detect_activation_by_controller(controller_state)
+                || GetAsyncKeyState_Not_Zero(winuser::VK_PAUSE)
             {
                 active = !active;
                 if !detect_activation_by_controller(controller_state) {
@@ -283,7 +283,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if unsafe {(GetAsyncKeyState(winuser::VK_HOME) as u32 & 0x8000) != 0} {
+            if GetAsyncKeyState_Not_Zero(winuser::VK_HOME) {
                 active = !active;
                 capture_mouse = active;
 
@@ -301,7 +301,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if unsafe {(GetAsyncKeyState(winuser::VK_END) as u32 & 0x8000) != 0} {
+            if GetAsyncKeyState_Not_Zero(winuser::VK_END) {
                 active = !active;
                 capture_mouse = active;
 
@@ -318,7 +318,7 @@ pub fn main() -> Result<(), Error> {
                 thread::sleep(Duration::from_millis(500));
             }
 
-            if unsafe {active & (GetAsyncKeyState(winuser::VK_DELETE) as u32 & 0x8000 != 0)} {
+            if active & GetAsyncKeyState_Not_Zero(winuser::VK_DELETE) {
                 capture_mouse = !capture_mouse;
                 let c_status = if !capture_mouse {
                     "Deattached"
@@ -330,4 +330,8 @@ pub fn main() -> Result<(), Error> {
             }
         
     }
+}
+
+fn GetAsyncKeyState_Not_Zero(vKey: c_int) -> bool {
+   unsafe { GetAsyncKeyState(vKey) as u32 & 0x8000 != 0 }
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html